### PR TITLE
sites.md: Fix up formatting for Melbourne Bio sites

### DIFF
--- a/docs/sites.md
+++ b/docs/sites.md
@@ -35,8 +35,8 @@ VIC | Bureau of Meteorology  | | [http://www.bom.gov.au/](http://www.bom.gov.au/
 | | MASSIVE |
 | University of Melbourne  | Spartan | [https://dashboard.hpc.unimelb.edu.au/](https://dashboard.hpc.unimelb.edu.au/)
 | Melbourne Bioinformatics (UoM) | Barcoo | [https://www.melbournebioinformatics.org.au/](https://www.melbournebioinformatics.org.au/)
-| Melbourne Bioinformatics (UoM) | Merri |
-| Melbourne Bioinformatics (UoM) | Snowy |
+|  | Merri |
+|  | Snowy |
 | Swinburne University of Technology  | gSTAR | [https://supercomputing.swin.edu.au/](https://supercomputing.swin.edu.au/)
 | | OzStar |
 WA | Pawsey | Athena | [https://www.pawsey.org.au/](https://www.pawsey.org.au/)


### PR DESCRIPTION
A copy and paste error on my part left the Melbourne Bioinformatics sites each labelled with the site name, rather than just the first one.

Fixing that up now.