### PR TITLE
Remove former VLSCI systems

### DIFF
--- a/docs/sites.md
+++ b/docs/sites.md
@@ -34,9 +34,6 @@ VIC | Bureau of Meteorology  | | [http://www.bom.gov.au/](http://www.bom.gov.au/
 | Monash University  | MonARCH | http://monash.edu/
 | | MASSIVE | [https://massive.org.au](https://massive.org.au)
 | University of Melbourne  | Spartan | [https://dashboard.hpc.unimelb.edu.au/](https://dashboard.hpc.unimelb.edu.au/)
-| Melbourne Bioinformatics (UoM) | Barcoo | [https://www.melbournebioinformatics.org.au/](https://www.melbournebioinformatics.org.au/)
-|  | Merri |
-|  | Snowy |
 | Swinburne University of Technology  | gSTAR | [https://supercomputing.swin.edu.au/](https://supercomputing.swin.edu.au/)
 | | OzStar |
 WA | Pawsey | Athena | [https://www.pawsey.org.au/](https://www.pawsey.org.au/)


### PR DESCRIPTION
These HPC systems no longer exist, so must remove them.